### PR TITLE
add kof2011 and rubykansai party information

### DIFF
--- a/app/views/events/kansai04.html.haml
+++ b/app/views/events/kansai04.html.haml
@@ -155,6 +155,15 @@
                 バッジの参加者種別の書体は、
                 %a{:href => "http://yozvox.web.infoseek.co.jp/96D1954D94C5.html"}Y.OzFont毛筆版
                 を使用しています。
+            %div#party
+              %h3 懇親会
+              %dl
+                %dt 11月11日(金) 関西オープンソース2011主催 懇親会
+                %dd 情報が公開され次第リンクします。
+                %dt 11月12日(土) Ruby関西主催 懇親会
+                %dd
+                  ATND にて受け付けています。
+                  = link_to "関西Ruby会議04 懇親会", "http://atnd.org/events/20917"
             %div#access
               %h3 Map
               %div#map


### PR DESCRIPTION
新入り PEOPLE TO BE NOTIFIED の no6v です。

関西Ruby会議04関連の懇親会の情報を追加しました。

デプロイとatndのオープンとRuby会議日記でのアナウンスを
出来るだけ同期させたいのですが、デプロイのタイミングって
調整できるでしょうか？難しそうなら、
オープンとアナウンスだけ先に済ませようかと考えています。
ご検討くださいませ。よろしくお願いします！
